### PR TITLE
SSCS-9064:bintray to jitpack

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -22,10 +22,3 @@ jobs:
           java-version: 11
       - name: Build
         run: ./gradlew check
-      - name: Release
-        env:
-          BINTRAY_USER: jenkins-reform-hmcts
-          BINTRAY_KEY: ${{ secrets.BINTRAY_KEY }}
-          RELEASE_VERSION: ${{ github.ref }}
-        run: ./gradlew bintrayUpload
-        if: startsWith(github.ref, 'refs/tags')

--- a/.github/workflows/jitpack_build.yml
+++ b/.github/workflows/jitpack_build.yml
@@ -20,17 +20,17 @@ jobs:
         PACKAGES_FILE="packages.txt"
 
         touch ${PACKAGES_FILE}
-        echo "Wait for the CI build..."
-        sleep 30
 
-        # Try the URL 3 times before failing
+        # Try the URL 6 times before failing
         count=1
-        until [[ $count -gt 3 ]] || [[ $(cat ${PACKAGES_FILE} | wc -l | xargs ) -gt 1 ]] ; do
-          echo "Attempt ${count}/3"
+        until [[ $count -gt 6 ]] || grep -q build.log ${PACKAGES_FILE} ; do
+          echo "Attempt ${count}/6"
           STATUS=$(curl -s -o packages.txt -w "%{http_code}" --max-time 900 ${PACKAGES_URL})
 
           let count+=1
-          sleep 20
+          if [[ ${STATUS} -gt 399 ]]; then
+              sleep 30
+          fi
         done
 
         echo "::group::Files Available"

--- a/.github/workflows/jitpack_build.yml
+++ b/.github/workflows/jitpack_build.yml
@@ -1,0 +1,43 @@
+name: Trigger JitPack Build
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Trigger Build in JitPack
+      run: |
+        echo "Triggering JitPack build"
+
+        PACKAGES_URL="https://jitpack.io/com/github/${GITHUB_REPOSITORY}/${GITHUB_REF#refs/tags/}/"
+        PACKAGES_FILE="packages.txt"
+
+        touch ${PACKAGES_FILE}
+        echo "Wait for the CI build..."
+        sleep 30
+
+        # Try the URL 3 times before failing
+        count=1
+        until [[ $count -gt 3 ]] || [[ $(cat ${PACKAGES_FILE} | wc -l | xargs ) -gt 1 ]] ; do
+          echo "Attempt ${count}/3"
+          STATUS=$(curl -s -o packages.txt -w "%{http_code}" --max-time 900 ${PACKAGES_URL})
+
+          let count+=1
+          sleep 20
+        done
+
+        echo "::group::Files Available"
+        echo $(cat ${PACKAGES_FILE})
+        echo "::endgroup::"
+
+        if [[ ${STATUS} -gt 399 ]] ; then
+          echo "FAILURE: ${STATUS} response from JitPack"
+          exit 1
+        fi

--- a/build.gradle
+++ b/build.gradle
@@ -15,7 +15,7 @@ plugins {
 
 def buildNumber = System.getenv("RELEASE_VERSION")?.replace("refs/tags/", "") ?: "DEV-SNAPSHOT"
 
-group = 'uk.gov.hmcts.reform'
+group = 'com.github.hmcts'
 version = buildNumber
 
 sourceCompatibility = 11
@@ -99,9 +99,6 @@ dependencyCheck {
 repositories {
   mavenCentral()
   mavenLocal()
-  maven {
-    url "https://dl.bintray.com/hmcts/hmcts-maven"
-  }
   jcenter()
   mavenCentral()
 
@@ -109,9 +106,13 @@ repositories {
     url 'https://repo.spring.io/libs-milestone'
   }
 
-  // jitpack should be last resort
+  // jitpack was last resort but replaced bintray
   // see: https://github.com/jitpack/jitpack.io/issues/1939
   maven { url 'https://jitpack.io' }
+
+  maven {
+    url "https://dl.bintray.com/hmcts/hmcts-maven"
+  }
 }
 
 publishing {

--- a/jitpack.yml
+++ b/jitpack.yml
@@ -1,0 +1,5 @@
+jdk:
+  - openjdk11
+
+install:
+  - ./gradlew build publishToMavenLocal


### PR DESCRIPTION
### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-9064

### Change description ###
bintray is being decommissioned. Moving jar install to jitpack repo

**Does this PR introduce a breaking change?** (check one with "x")
```
[ ] Yes
[ x] No
```